### PR TITLE
Added Automotive Cyber Security Summit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Check out my [blog](https://jaredmichaelsmith.com/blog) or follow me on [Twitter
 - [Remote Exploitation of an Unaltered Passenger Vehicle](https://www.youtube.com/watch?v=OobLb1McxnI) - DEFCON 23 talk by Chris Valasek and Charlie Miller give their now famous talk on hacking into a Jeep remotely and stopping it dead in its tracks.
 - [Adventures in Automotive Networks and Control Units](https://www.youtube.com/watch?v=n70hIu9lcYo) - DEFCON 21 talk by Chris Valasek and Charlie Miller on automotive networks.
 - [Can You Trust Autonomous Vehicles?](https://www.youtube.com/watch?v=orWqKWvIW_0) - DEFCON 24 talk by Jianhao Liu, Chen Yan, Wenyuan Xu
+- [The Cyber Security Automotve Summit](http://www.automotivecybersecurity.com/) - A conference dedicated to automotive cyber security involving most of the big players on this aspect.
 
 ## Books
 


### PR DESCRIPTION
Added the Automotive Cyber Security website to the list of presentations available (although it is not a presentation in itself, it has useful data and presentations/ information may be taken from the website).

Furthermore, if you feel the info is not relevant for that topic, a new topic may be added for the 'Conferences'.
